### PR TITLE
Fix/prometheus enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Available environment variables for runtime configuration:
   **HTTP_PROXY**, and will be used for both Maven builds and Java runtime.
 * **`no_proxy`** / **NO_PROXY** A comma separated lists of hosts, IP addresses or domains that can be accessed directly.
   This will be used for both Maven builds and Java runtime.
+* **AB_PROMETHEUS_OFF** Disables the use of Prometheus Java Agent.
+* **AB_PROMETHEUS_PORT** Port to use for the Prometheus JMX Exporter.
 
 ### jkube-tomcat9-binary-s2i
 

--- a/jkube-java-binary-s2i.yaml
+++ b/jkube-java-binary-s2i.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "quay.io/jkube/jkube-java-binary-s2i"
 description: "Platform for building and running plain Java applications (fat-jar and flat classpath)"
 version: "latest"
-from: "registry.access.redhat.com/ubi8/ubi-minimal:8.0"
+from: "registry.access.redhat.com/ubi8/ubi-minimal:8.2"
 
 labels:
   - name: "io.k8s.display-name"
@@ -34,7 +34,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.41.0
+        ref: 0.42.0
   install:
     - name: jboss.container.microdnf-bz-workaround
     - name: jboss.container.openjdk.jdk

--- a/jkube-java-binary-s2i.yaml
+++ b/jkube-java-binary-s2i.yaml
@@ -49,6 +49,7 @@ modules:
     - name: jboss.container.prometheus
     - name: jboss.container.util.logging.bash
     - name: jboss.container.java.jvm.bash.debug-options-override
+    - name: jboss.container.prometheus-override
     - name: s2i-scripts
 
 run:

--- a/modules/jboss.container.prometheus-override/artifacts/opt/jboss/container/prometheus/prometheus-opts
+++ b/modules/jboss.container.prometheus-override/artifacts/opt/jboss/container/prometheus/prometheus-opts
@@ -1,0 +1,27 @@
+#!/bin/sh
+# ==============================================================================
+# Configure JVM options for Prometheus Agent
+#
+# Usage: JAVA_OPTS="$JAVA_OPTS $(source ${JBOSS_CONTAINER_PROMETHEUS_MODULE}/prometheus-opts && get_prometheus_opts)"
+#
+# Env Vars respected:
+#
+# AB_PROMETHEUS_OFF: Disables the use of Prometheus Java Agent.
+#
+# AB_PROMETHEUS_PORT: Port to use for the Prometheus JMX Exporter.
+#   Defaults to 9779.
+#
+# AB_PROMETHEUS_JMX_EXPORTER_CONFIG: Path to configuration to use for the
+#   Prometheus JMX Exporter.  Defaults to:
+#   /opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+#
+
+source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
+
+# echo's a complete -javaagent option based on the above variables.
+function get_prometheus_opts() {
+    if ! echo "${AB_PROMETHEUS_OFF:-false}" | grep -q -e '^\(true\|y\|yes\|1\)$'; then
+        echo "-javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=${AB_PROMETHEUS_PORT:-9779}:${AB_PROMETHEUS_JMX_EXPORTER_CONFIG:-/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml}"
+    fi
+    echo ""
+}

--- a/modules/jboss.container.prometheus-override/configure.sh
+++ b/modules/jboss.container.prometheus-override/configure.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root ${ARTIFACTS_DIR}
+chmod 755 ${ARTIFACTS_DIR}/opt/jboss/container/prometheus/prometheus-opts
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd

--- a/modules/jboss.container.prometheus-override/module.yaml
+++ b/modules/jboss.container.prometheus-override/module.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+name: jboss.container.prometheus-override
+version: 1.0.0
+description: ^
+  Overrides prometheus options script defined in jboss module.
+  https://github.com/jboss-openshift/cct_module/tree/8411125f8e1b45d48c93c8bcd51d39541ce4a755/jboss/container/prometheus
+
+envs:
+  - name: AB_PROMETHEUS_OFF
+    description: Disable the use of prometheus agent
+    example: true
+  - name: AB_PROMETHEUS_PORT
+    description: Port to use for the Prometheus JMX Exporter.
+    example: 9799
+
+execute:
+  - script: configure.sh


### PR DESCRIPTION
Relates to https://github.com/eclipse/jkube/issues/358

Provides support for Eclipse JKube's (Fabric8 Maven Plugin - FMP) standard environment variables to enable Prometheus Java Agent by default.

Users need now to opt-out by providing an `AB_PROMETHEUS_OFF=true` environment variable.

Base image and JBoss CEKit modules version have been upgraded too.