### PR TITLE
feat: bump base image and module deps for java-binary-s2i

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install CEKit
-        uses: manusa/actions-setup-cekit@v1.0.2
+        uses: manusa/actions-setup-cekit@v1.1.0
       - name: Build java-binary-s2i
         run: |
           echo "Building quay.io/jkube/${{ matrix.image }}:${TAG}"

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install CEKit
-        uses: manusa/actions-setup-cekit@v1.0.2
+        uses: manusa/actions-setup-cekit@v1.1.0
       - name: Get Tag
         id: get_version
         run: |

--- a/jkube-java-binary-s2i.yaml
+++ b/jkube-java-binary-s2i.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "quay.io/jkube/jkube-java-binary-s2i"
 description: "Platform for building and running plain Java applications (fat-jar and flat classpath)"
 version: "latest"
-from: "registry.access.redhat.com/ubi8/ubi-minimal:8.2"
+from: "registry.access.redhat.com/ubi8/ubi-minimal:8.3"
 
 labels:
   - name: "io.k8s.display-name"
@@ -34,7 +34,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.42.0
+        ref: 0.44.0
   install:
     - name: jboss.container.microdnf-bz-workaround
     - name: jboss.container.openjdk.jdk


### PR DESCRIPTION
- OpenJDK version is "11.0.9.1" 2020-11-04 LTS

To be followed by a release and an update of the java-binary-s2i tag dependency in JKube:
https://github.com/eclipse/jkube/blob/104a4d9795eb1c4b8290723a23311328cc619ce4/jkube-kit/parent/pom.xml#L79