### PR TITLE
feat: adding new image build with the latest tomcat stable version

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ['jkube-java', 'jkube-java-11', 'jkube-jetty9', 'jkube-karaf', 'jkube-tomcat9']
+        image: ['jkube-java', 'jkube-java-11', 'jkube-jetty9', 'jkube-karaf', 'jkube-tomcat9', 'jkube-tomcat']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ['jkube-java', 'jkube-java-11', 'jkube-jetty9', 'jkube-karaf', 'jkube-tomcat9']
+        image: ['jkube-java', 'jkube-java-11', 'jkube-jetty9', 'jkube-karaf', 'jkube-tomcat9', 'jkube-tomcat']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/jkube-tomcat.yaml
+++ b/jkube-tomcat.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+
+name: "quay.io/jkube/jkube-tomcat"
+description: "Base image for Apache Tomcat webapp deployments"
+version: "latest"
+from: "tomcat:10.0.18-jdk17-temurin"
+
+labels:
+  - name: "io.k8s.display-name"
+    value: "Eclipse JKube - Tomcat"
+  - name: "io.k8s.description"
+    value: "Base image for Apache Tomcat webapp deployments"
+  - name: "io.openshift.tags"
+    value: "builder,jkube,tomcat"
+  - name: "io.openshift.s2i.scripts-url"
+    value: "image:///usr/local/s2i"
+  - name: "io.openshift.s2i.destination"
+    value: "/tmp"
+  - name: "maintainer"
+    value: "Eclipse JKube Team <jkube-dev@eclipse.org>"
+
+envs:
+  - name: DEPLOYMENTS_DIR
+    value: "/deployments"
+  - name: CATALINA_HOME
+    value: "/usr/local/tomcat"
+  - name: PATH
+    value: "$PATH:$CATALINA_HOME/bin:/usr/local/s2i"
+
+packages:
+  manager: microdnf
+
+modules:
+  repositories:
+    - path: modules
+  install:
+    - name: s2i-tomcat
+
+ports:
+  - value: 8080
+
+run:
+  user: 1000
+  cmd:
+    - "/usr/local/s2i/run"

--- a/scripts/test-jkube-tomcat.sh
+++ b/scripts/test-jkube-tomcat.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+trap 'exit' ERR
+BASEDIR=$(dirname "$BASH_SOURCE")
+source "$BASEDIR/common.sh"
+
+IMAGE="quay.io/jkube/jkube-tomcat:$TAG_OR_LATEST"
+
+assertContains "$(dockerRun 'id')" "uid=1000 gid=0(root) groups=0(root)" || reportError "Invalid run user, should be 1000"
+
+assertContains "$(dockerRun 'java -version')" 'openjdk version "17.0.1"' || reportError "Invalid Java version"
+
+# S2I scripts
+s2i="$(dockerRun 'ls -la /usr/local/s2i/')"
+assertContains "$s2i" "assemble" || reportError "assemble not found"
+assertContains "$s2i" "run" || reportError "run not found"
+assembleScript="$(dockerRun 'cat /usr/local/s2i/assemble')"
+assertContains "$assembleScript" 'copy_dir bin$' || reportError "Invalid s2i assemble script"
+assertContains "$assembleScript" 'copy_dir deployments$' || reportError "Invalid s2i assemble script"
+assertContains "$assembleScript" 'copy_dir maven$' || reportError "Invalid s2i assemble script"
+
+# Env
+env_variables="$(dockerRun 'env')"
+assertContains "$env_variables" "JAVA_HOME=/opt/java/openjdk$" \
+  || reportError "JAVA_HOME invalid"
+assertContains "$env_variables" "JAVA_VERSION=jdk-17.0.1+12$" \
+  || reportError "JAVA_VERSION invalid"
+assertContains "$env_variables" "CATALINA_HOME=/usr/local/tomcat$" \
+  || reportError "CATALINA_HOME invalid"
+assertContains "$env_variables" "TOMCAT_VERSION=10.0.18$" \
+  || reportError "TOMCAT_VERSION invalid"
+assertContains "$env_variables" "DEPLOYMENTS_DIR=/deployments$" \
+  || reportError "DEPLOYMENTS_DIR invalid"


### PR DESCRIPTION
part of https://github.com/eclipse/jkube/issues/1324

Adding `quay.io/jkube/tomcat` alongside with `quay.io/jkube/tomcat9`

-  `quay.io/jkube/tomcat` is based on the latest tomcat stable version: 10.0.18. supports jakarta ee
-  `quay.io/jkube/tomcat` is based on the latest tomcat 9.x.x. supports legacy java ee imports