### PR TITLE
feat: jkube-karaf images use ubi9 base image

### DIFF
--- a/jkube-karaf.yaml
+++ b/jkube-karaf.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "quay.io/jkube/jkube-karaf"
 description: "Base image for Apache Karaf deployments"
 version: "latest"
-from: "registry.access.redhat.com/ubi8/openjdk-17:1.16"
+from: "registry.access.redhat.com/ubi9/openjdk-17:1.16"
 
 labels:
   - name: "io.k8s.display-name"

--- a/scripts/test-jkube-karaf.sh
+++ b/scripts/test-jkube-karaf.sh
@@ -41,5 +41,3 @@ assertContains "$env_variables" "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE=/opt/jboss
   || reportError "JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE invalid"
 assertContains "$env_variables" "JBOSS_CONTAINER_S2I_CORE_MODULE=/opt/jboss/container/s2i/core/$" \
   || reportError "JBOSS_CONTAINER_S2I_CORE_MODULE invalid"
-assertContains "$env_variables" "AB_PROMETHEUS_JMX_EXPORTER_CONFIG=/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml$" \
-  || reportError "AB_PROMETHEUS_JMX_EXPORTER_CONFIG invalid"


### PR DESCRIPTION
Part of https://github.com/eclipse/jkube/issues/1690

Removed Prometheus JMX exporter check.
UBI9 image doesn't include the Java agent.
However, KarafGenerator doesn't use it.